### PR TITLE
fix: pin atticd postgres user to work around upstream regression

### DIFF
--- a/server/services/atticd.nix
+++ b/server/services/atticd.nix
@@ -28,7 +28,7 @@
 
     settings = {
       listen = "[::]:5867";
-      database.url = "postgres:///atticd";
+      database.url = "postgresql:///atticd?host=/run/postgresql&user=atticd";
 
       # Data chunking
       #


### PR DESCRIPTION
attic-0-unstable-2026-07-06 (SeaORM 2.0 / sqlx 0.9 bump) connects as "anonymous" when the database URL has no username, breaking peer auth. zhaofengli/attic#352